### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I'm **Caleb Denio**, a fullstack developer and active [Hack Club](https://hackcl
 
 💼 https://linkedin.com/in/calebdenio
 
-You can also find me on the [Hack Club Slack!](hackclub.com/slack/)
+You can also find me on the [Hack Club Slack!](https://hackclub.com/slack)
 
 ## Open source contributions
 


### PR DESCRIPTION
This is Ishan from the Slack.
Just fixed a broken link that was missing the `https://` part (and so was treated as a relative link).
Just so you know, I am not taking part in Hacktoberfest (lol)